### PR TITLE
Build on trusty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 project(minimum_distance_plugin)
 
@@ -20,8 +20,11 @@ target_link_libraries(minimum_distance_plugin PRIVATE
 target_include_directories(minimum_distance_plugin PRIVATE
   ${CCD_INCLUDE_DIRS}
   ${GAZEBO_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIRS})
+  ${EIGEN3_INCLUDE_DIR})
 
-target_compile_features(minimum_distance_plugin PRIVATE
-  cxx_aggregate_default_initializers)
+target_compile_options(minimum_distance_plugin PRIVATE -std=c++11)
 
+install(TARGETS minimum_distance_plugin
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib/static)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,49 @@
 # minimum_distance_plugin
+## Installing
+This plugin is built for Ubuntu Trusty (14.04).
 
+First fetch dependencies using apt:
+
+```
+  sudo apt install gazebo7
+  sudo apt install libgazebo7-dev
+  sudo apt install libeigen3-dev
+```
+
+Second, download and install libccd 2.0
+
+```
+cd && mkdir libccd-build && cd libccd-build
+wget https://github.com/danfis/libccd/archive/v2.0.tar.gz
+tar -xzvf v2.0.tar.gz
+mkdir libccd-2.0/build && cd libccd-2.0/build
+cmake -DCCD_DOUBLE:BOOL=ON -DCMAKE_INSTALL_PREFIX=/usr/local ..
+make
+sudo make install
+```
+
+Finally download and install this plugin
+
+```
+cd && mkdir gazebo-minimum-distance-plugin-build && cd gazebo-minimum-distance-plugin-build
+git clone https://github.com/osrf/minimum_distance_plugin.git
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local ..
+make
+sudo make install
+```
+
+## Quick start
+
+```
+. /usr/share/gazebo/setup.sh
+export GAZEBO_PLUGIN_PATH=/usr/local/lib:$GAZEBO_PLUGIN_PATH
+export LD_LIBRARY_PATH=/usr/local/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+gazebo --verbose ~/gazebo-minimum-distance-plugin-build/worlds/test.world
+```
+
+Visualize the topic `/default/minimum_distance_plugin/BoxTest`
+
+## About the Plugin
 This is a Gazebo "world plugin" for calculating the minimum distance between convex shapes. The convex shapes are attached to links within the simulation.
 
 :warning: The `distance` field in the `gazebo::msgs::Contact` that gets published by this plugin refers to **penetration** distance. For bodies that are separated, this value will be negative. Therefore, this plugin is actually reporting the *maximum penetration* distance (which is the negative of the *minimum separation* distance).

--- a/ccd_eigen.hpp
+++ b/ccd_eigen.hpp
@@ -28,6 +28,10 @@
 #include <ccd/ccd.h>
 #include <Eigen/Geometry>
 #include <iostream>
+#include <type_traits>
+
+static_assert(std::is_same<double, ccd_real_t>::value,
+    "This plugin requires libccd to be built with double precision support.");
 
 namespace ccdw {
 


### PR DESCRIPTION
* Updates `CMakeLists.txt` to build on Ubuntu 14.04
* Assert that libccd has double precision support
* Add installation instructions for trusty